### PR TITLE
Improve fixed window performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AssociativeWindowAggregation"
 uuid = "444271a7-5434-4a02-b82b-0e30a9223c60"
 authors = ["Thomas Gillam <tpgillam@googlemail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Accumulate result of appying binary associative operators on rolling windows.
 
 The algorithm is constant time with respect to the window length, and is numerically stable. 
 Details can be found in the [documentation](https://tpgillam.github.io/AssociativeWindowAggregation.jl/dev). 
-For demonstrations of use of the package, see the [examples](https://tpgillam.github.io/AssociativeWindowAggregation.jl/dev/examples).
+For demonstrations, see the [documentation examples](https://tpgillam.github.io/AssociativeWindowAggregation.jl/dev/examples) as well as the project under `examples/`.

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -2,3 +2,4 @@
 AssociativeWindowAggregation = "444271a7-5434-4a02-b82b-0e30a9223c60"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+RollingFunctions = "b0e4dd01-7b14-53d8-9b45-175a3e362653"

--- a/examples/benchmark.jl
+++ b/examples/benchmark.jl
@@ -1,12 +1,35 @@
 using AssociativeWindowAggregation
 using BenchmarkTools
+using RollingFunctions
 
-function run_example(window::Integer, num_points::Integer)
+function run_example(window::Integer, data::Vector{Int})
     state = FixedWindowAssociativeOp{Int,+}(window)
-    for _ in 1:num_points
-        update_state!(state, 1)
+    result = Vector{Int}(undef, length(data) - (window - 1))
+    i = 1
+    for x in data
+        update_state!(state, x)  # Do work
+        window_full(state) || continue  # Only record numbers when the window is full
+        @inbounds result[i] = window_value(state)  # Extract mean
+        i += 1
     end
-    return window_value(state)
+    return result
 end
 
-@benchmark run_example(100, 10000)
+function run_rolling(window::Integer, data::Vector{Int})
+    return rolling(sum, data, window)
+end
+
+
+data = rand(-100:100, 100000)
+window = 200
+
+@assert run_example(window, data) == run_rolling(window, data)
+
+@benchmark run_example(window, data)
+@benchmark run_rolling(window, data)
+
+# Observations on an M1 MacBook Air, running Julia 1.6.2:
+#
+# Currently this package is faster for windows >= 20, but is slower for smaller windows.
+# This is because we have better complexity [O(1) vs O(n) for RollingFunctions], however we
+# incur some additional overhead that results in worse constant factors.

--- a/src/fixed_window_associative_op.jl
+++ b/src/fixed_window_associative_op.jl
@@ -25,7 +25,10 @@ mutable struct FixedWindowAssociativeOp{T,Op}
         if window < 1
             throw(ArgumentError("Got window $window, but it must be positive."))
         end
-        return new(WindowedAssociativeOp{T,Op}(), window)
+        window_state = WindowedAssociativeOp{T,Op}()
+        sizehint!(window_state.previous_cumsum, window)
+        sizehint!(window_state.values, window)
+        return new(window_state, window)
     end
 end
 

--- a/src/fixed_window_associative_op.jl
+++ b/src/fixed_window_associative_op.jl
@@ -1,3 +1,5 @@
+using DataStructures: CircularBuffer
+
 """
     FixedWindowAssociativeOp{T,Op}
 
@@ -10,7 +12,7 @@ State necessary for accumulation over a rolling window of fixed size.
     zero.
 """
 mutable struct FixedWindowAssociativeOp{T,Op}
-    window_state::WindowedAssociativeOp{T,Op}
+    window_state::WindowedAssociativeOp{T,Op,CircularBuffer{T}}
     remaining_window::Int
 
     """
@@ -25,9 +27,10 @@ mutable struct FixedWindowAssociativeOp{T,Op}
         if window < 1
             throw(ArgumentError("Got window $window, but it must be positive."))
         end
-        window_state = WindowedAssociativeOp{T,Op}()
-        sizehint!(window_state.previous_cumsum, window)
-        sizehint!(window_state.values, window)
+        window_state = WindowedAssociativeOp{T,Op,CircularBuffer{T}}(
+            CircularBuffer{T}(window),
+            CircularBuffer{T}(window)
+        )
         return new(window_state, window)
     end
 end

--- a/src/windowed_associative_op.jl
+++ b/src/windowed_associative_op.jl
@@ -47,7 +47,7 @@ mutable struct WindowedAssociativeOp{T,Op}
     previous_cumsum::Vector{T}
     ri_previous_cumsum::Int
     values::Vector{T}
-    sum::Union{Nothing,T}
+    sum::T  # Will start uninitialised.
 
     """
         WindowedAssociativeOp{T,Op}
@@ -58,7 +58,7 @@ mutable struct WindowedAssociativeOp{T,Op}
     - `T`: The type of the values of the array.
     - `Op`: Any binary, associative, function.
     """
-    WindowedAssociativeOp{T,Op}() where {T,Op} = new{T,Op}(T[], 0, T[], nothing)
+    WindowedAssociativeOp{T,Op}() where {T,Op} = new{T,Op}(T[], 0, T[])
 end
 
 """

--- a/src/windowed_associative_op.jl
+++ b/src/windowed_associative_op.jl
@@ -35,31 +35,39 @@ window length.
 # Type parameters
 - `T`: The type of the values of the array.
 - `Op`: Any binary, associative, function.
+- `V`: The abstract vector subtype used for internal state.
 
 # Fields
 - `previous_cumsum::Vector{T}`: Corresponds to array `A` above.
 - `ri_previous_cumsum::Int`: A reverse index into `previous_cumsum`, once it contains
     values. It should be subtracted from `end` in order to obtain the appropriate index.
 - `values::Vector{T}`: Corresponds to array `B` above.
-- `sum::Union{Nothing, T}`: The sum of the elements in values.
+- `sum::T`: The sum of the elements in values.
 """
-mutable struct WindowedAssociativeOp{T,Op}
-    previous_cumsum::Vector{T}
+mutable struct WindowedAssociativeOp{T,Op,V <: AbstractVector{T}}
+    previous_cumsum::V
     ri_previous_cumsum::Int
-    values::Vector{T}
+    values::V
     sum::T  # Will start uninitialised.
 
-    """
-        WindowedAssociativeOp{T,Op}
-
-    Create a new, empty, instance of WindowedAssociativeOp.
-
-    # Type parameters
-    - `T`: The type of the values of the array.
-    - `Op`: Any binary, associative, function.
-    """
-    WindowedAssociativeOp{T,Op}() where {T,Op} = new{T,Op}(T[], 0, T[])
+    function WindowedAssociativeOp{T,Op,V}(
+        previous_cumsum::V,
+        values::V
+    ) where {T,Op,V <: AbstractVector{T}}
+        return new{T,Op,V}(previous_cumsum, 0, values)
+    end
 end
+
+"""
+    WindowedAssociativeOp{T,Op}
+
+Create a new, empty, instance of WindowedAssociativeOp.
+
+# Type parameters
+- `T`: The type of the values of the array.
+- `Op`: Any binary, associative, function.
+"""
+WindowedAssociativeOp{T,Op}() where {T,Op} = WindowedAssociativeOp{T,Op,Vector{T}}(T[], T[])
 
 """
     update_state!(
@@ -84,7 +92,7 @@ function update_state!(
     state::WindowedAssociativeOp{T,Op},
     value,
     num_dropped_from_window::Integer
-)::WindowedAssociativeOp{T,Op} where {T,Op}
+) where {T,Op}
     # Our index into previous_cumsum is advanced by the number of values we drop from the
     # window.
     state.ri_previous_cumsum += num_dropped_from_window
@@ -149,7 +157,6 @@ function update_state!(
 
     return state
 end
-
 
 """
     window_value(state::WindowedAssociativeOp{T,Op})::T where T

--- a/test/windowed_associative_op.jl
+++ b/test/windowed_associative_op.jl
@@ -6,7 +6,6 @@
                 @test state.previous_cumsum == T[]
                 @test state.ri_previous_cumsum == 0
                 @test state.values == T[]
-                @test isnothing(state.sum)
             end
         end
     end


### PR DESCRIPTION
Use circular buffers to provide a significant (~2x) speedup for the case of a fixed window.