### PR TITLE
Skip bounds checking for fixed window case

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AssociativeWindowAggregation"
 uuid = "444271a7-5434-4a02-b82b-0e30a9223c60"
 authors = ["Thomas Gillam <tpgillam@googlemail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/fixed_window_associative_op.jl
+++ b/src/fixed_window_associative_op.jl
@@ -52,7 +52,9 @@ function update_state!(state::FixedWindowAssociativeOp, value)
         1
     end
 
-    update_state!(state.window_state, value, num_dropped_from_window)
+    # With @inbounds, we assert that num_dropped_from_window will never exceed the size of
+    # the window.
+    @inbounds update_state!(state.window_state, value, num_dropped_from_window)
     return state
 end
 

--- a/src/windowed_associative_op.jl
+++ b/src/windowed_associative_op.jl
@@ -88,7 +88,7 @@ window, and return `state` (which will have been mutated).
 # Returns
 - `::WindowedAssociativeOp{T,Op}`: The instance `state` that was passed in.
 """
-function update_state!(
+Base.@propagate_inbounds function update_state!(
     state::WindowedAssociativeOp{T,Op},
     value,
     num_dropped_from_window::Integer
@@ -107,7 +107,7 @@ function update_state!(
         # We may also need to discard elements from values. This could happen if
         # num_dropped_from_window > 1.
         num_values_to_remove = - elements_remaining - 1
-        if num_values_to_remove > length(state.values)
+        @boundscheck if num_values_to_remove > length(state.values)
             throw(ArgumentError(
                 "num_dropped_from_window = $num_dropped_from_window is out of range"
             ))


### PR DESCRIPTION
`update_state!` does a check that `num_dropped_from_window` isn't too large. Mark this with `@boundscheck`, and skip it for the fixed window case.