### PR TITLE
Refactor general case into `push!` and `popfirst!`

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "blue"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AssociativeWindowAggregation"
 uuid = "444271a7-5434-4a02-b82b-0e30a9223c60"
-authors = ["Thomas Gillam <tpgillam@googlemail.com>"]
-version = "0.3.2"
+authors = ["Tom Gillam <tpgillam@googlemail.com>"]
+version = "0.4.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/docs/src/reference/base.md
+++ b/docs/src/reference/base.md
@@ -1,10 +1,11 @@
 # General window
 
-A state to represent a window of aribtrarily variable capacity.
+A state to represent a window of arbitrarily variable capacity.
 
-Every time a new value is pushed onto the end of the window, we must specify how many values are removed from the front of the window.
+We push new values onto the window with [`Base.push!`](@ref).
+We can remove old values from the window with [`Base.popfirst!`](@ref).
 
 ```@autodocs
-Modules = [AssociativeWindowAggregation]
+Modules = [AssociativeWindowAggregation, Base]
 Pages = ["base.jl"]
 ```

--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -16,9 +16,7 @@ mutable struct FixedWindowAssociativeOp{T,Op,Op!}
     window_state::WindowedAssociativeOp{T,Op,Op!,CircularBuffer{T}}
     remaining_window::Int
 
-    function FixedWindowAssociativeOp{T,Op,Op!}(
-        window::Integer
-    ) where {T,Op,Op!}
+    function FixedWindowAssociativeOp{T,Op,Op!}(window::Integer) where {T,Op,Op!}
         window < 1 && throw(ArgumentError("Got window $window, but it must be positive."))
         window_state = WindowedAssociativeOp{T,Op,Op!,CircularBuffer{T}}(
             CircularBuffer{T}(window - 1), CircularBuffer{T}(window)
@@ -50,7 +48,8 @@ function update_state!(state::FixedWindowAssociativeOp, value)
 
     # With @inbounds, we assert that num_dropped_from_window will never exceed the size of
     # the window.
-    @inbounds update_state!(state.window_state, value, num_dropped_from_window)
+    @inbounds popfirst!(state.window_state, num_dropped_from_window)
+    push!(state.window_state, value)
     return state
 end
 

--- a/src/time.jl
+++ b/src/time.jl
@@ -84,7 +84,8 @@ function update_state!(state::TimeWindowAssociativeOp, time, value)
         num_dropped_from_window += 1
     end
 
-    update_state!(state.window_state, value, num_dropped_from_window)
+    @inbounds popfirst!(state.window_state, num_dropped_from_window)
+    push!(state.window_state, value)
 
     if !state.window_full && num_dropped_from_window > 0
         # The window has now filled; record this for use in `window_full` below.

--- a/test/base.jl
+++ b/test/base.jl
@@ -9,4 +9,32 @@
             end
         end
     end
+
+    @testset "simple" begin
+        state = WindowedAssociativeOp{Int64,+}()
+        @test window_size(state) == 0
+
+        push!(state, 1)
+        @test window_size(state) == 1
+        @test window_value(state) == 1
+
+        push!(state, 2)
+        push!(state, 3, 4)
+        @test window_size(state) == 4
+        @test window_value(state) == 10
+
+        popfirst!(state)
+        @test window_size(state) == 3
+        @test window_value(state) == 9
+
+        popfirst!(state, 2)
+        @test window_size(state) == 1
+        @test window_value(state) == 4
+        @test_throws ArgumentError popfirst!(state, 2)
+        @test window_size(state) == 1
+        @test window_value(state) == 4
+
+        popfirst!(state, 1)
+        @test window_size(state) == 0
+    end
 end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,6 +1,4 @@
-function test_fixed_window(
-    values, op; op_bang=nothing, approximate_equality::Bool=false
-)
+function test_fixed_window(values, op; op_bang=nothing, approximate_equality::Bool=false)
     # For later comparison, to ensure that we don't mutate any of these
     values_copy = deepcopy(values)
 


### PR DESCRIPTION
This makes the logic a bit easier to understand, and fixes a couple of possible bugs.